### PR TITLE
Fixed image upload: read from imagepath, not filename

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -482,7 +482,7 @@ module.exports = class Client extends EventEmitter
             puturl = body?.sessionStatus?.externalFieldTransfers?[0]?.putInfo?.url
             log.debug 'image resume upload to:', puturl
         .then -> Q.Promise (rs, rj) ->
-            fs.readFile filename, plug(rs, rj)
+            fs.readFile imagefile, plug(rs, rj)
         .then (buf) ->
             log.debug 'image resume uploading'
             chatreq.baseReq puturl, 'application/octet-stream', buf


### PR DESCRIPTION
The path of the file to upload was misspelled in `fs.readFile`, only filename was used instead. That made impossible to upload images when not in current folder.