### PR TITLE
add aliases for lowercase methods

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -542,7 +542,35 @@ module.exports = class Client extends EventEmitter
             log.debug 'image resume upload finished'
             body?.sessionStatus?.additionalInfo?['uploader_service.GoogleRupioAdditionalInfo']?.completionInfo?.customerSpecificInfo?.photoid
 
+# aliases list
+aliases = [
+    'logLevel',
+    'sendChatMessage',
+    'setActiveClient',
+    'syncAllNewEvents',
+    'getSelfInfo',
+    'setConversationNotificationLevel',
+    'setFocus',
+    'setTyping',
+    'setPresence',
+    'queryPresence',
+    'removeUser',
+    'deleteConversation',
+    'updateWatermark',
+    'addUser',
+    'renameConversation',
+    'createConversation',
+    'getConversation',
+    'syncRecentConversations',
+    'searchEntities',
+    'getEntityById',
+    'sendEasteregg',
+    'uploadImage'
+]
 
+# set aliases
+aliases.forEach((alias) ->
+  Client.prototype[alias] = Client.prototype[alias.toLowerCase()])
 
 
 


### PR DESCRIPTION
imo the documentation should also be changed to the camelcase methods only. 
But imo the lowercase methods should also be removed completely.

What do you think?