### PR TITLE
Add method to sync client cookies to web session.

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -6,6 +6,7 @@ syspath         = require 'path'
 log             = require 'bog'
 fs              = require 'fs'
 Q               = require 'q'
+moment          = require('moment')
 
 {plug, fmterr, wait} = require './util'
 
@@ -214,6 +215,15 @@ module.exports = class Client extends EventEmitter
         !!(@init.apikey and @init.email and @init.headerdate and @init.headerversion and
         @init.headerid and @init.clientid)
 
+    syncCookies: (sess) ->
+        @jarstore.getAllCookies (e, cookies) ->
+            cookies.forEach (cookie) ->
+                schema = if cookie.secure then "https" else "http"
+                host = if cookie?.domain?[0] is "." then cookie.domain.substr(1) else cookie.domain
+                p = {url: schema + '://' + host, name: cookie.key, value: cookie.value, domain: host, path: cookie.path, secure: cookie.secure, httpOnly: cookie.httpOnly, expirationDate: moment(cookie.expires).unix(), sameSite: cookie.sameSite}
+                sess.cookies.set(p)
+                .catch (e) ->
+                    return
 
     # makes the header required at the start of each api call body.
     _requestBodyHeader: ->


### PR DESCRIPTION
Rarely we can end up at a point where the electron web view has no cookies, but the client cookies are still present. This causes issues when it tries to load urls and such (thumbnails will fail to load) because no cookies are present.
This PR adds a method to sync the client cookies to an electron web session.